### PR TITLE
FFA-99 Injecting GoogleSignInClient on ProfileViewModel and signing o…

### DIFF
--- a/app/src/main/java/com/digitalsolution/familyfilmapp/ui/screens/profile/ProfileViewModel.kt
+++ b/app/src/main/java/com/digitalsolution/familyfilmapp/ui/screens/profile/ProfileViewModel.kt
@@ -3,6 +3,7 @@ package com.digitalsolution.familyfilmapp.ui.screens.profile
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.digitalsolution.familyfilmapp.model.local.User
+import com.google.android.gms.auth.api.signin.GoogleSignInClient
 import com.google.firebase.auth.FirebaseAuth
 import dagger.hilt.android.lifecycle.HiltViewModel
 import javax.inject.Inject
@@ -17,6 +18,7 @@ import kotlinx.coroutines.launch
 @HiltViewModel
 class ProfileViewModel @Inject constructor(
     private val firebaseAuth: FirebaseAuth,
+    private val googleSignInClient: GoogleSignInClient,
 ) : ViewModel() {
 
     private val _state = MutableStateFlow(ProfileUiState())
@@ -43,5 +45,6 @@ class ProfileViewModel @Inject constructor(
 
     fun logOut() {
         firebaseAuth.signOut()
+        googleSignInClient.signOut()
     }
 }


### PR DESCRIPTION
## 📝 Description

When user logs out from Profile Screen it logs out also from GoogleClient. This way, when you log in with google again, it always asks for you to choose an account, before it was using the last account used.

## ✅ How to test

Log in with google, log out, log in with google again, you'll see is asking again for you to choose an account.

### 📎 Utils links

- [x] Jira ticket: https://apptolast.atlassian.net/browse/FFA-99
