### PR TITLE
FFA-172 Correctly use user ID instead of UID

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -36,8 +36,8 @@ android {
         applicationId = "com.apptolast.familyfilmapp"
         minSdk = 26
         targetSdk = 35
-        versionCode = 15
-        versionName = "0.3.13"
+        versionCode = 16
+        versionName = "0.3.14"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables.useSupportLibrary = true

--- a/app/src/main/java/com/apptolast/familyfilmapp/model/local/User.kt
+++ b/app/src/main/java/com/apptolast/familyfilmapp/model/local/User.kt
@@ -5,14 +5,14 @@ import com.google.firebase.auth.FirebaseUser
 import java.util.Locale
 
 data class User(
-    val uid: String,
+    val id: String,
     val email: String,
     val userName: String,
     val language: String,
     val statusMovies: Map<String, MovieStatus>, // Map with key-value pair: MovieId, Status
 ) {
     constructor() : this(
-        uid = "",
+        id = "",
         email = "",
         userName = "",
         language = "",
@@ -21,7 +21,7 @@ data class User(
 }
 
 fun FirebaseUser.toDomainUserModel(): User = User(
-    uid = this.uid,
+    id = this.uid,
     email = this.email ?: "email not found",
     userName = this.displayName ?: "display name not found",
     language = Locale.getDefault().toLanguageTag(),

--- a/app/src/main/java/com/apptolast/familyfilmapp/model/local/User.kt
+++ b/app/src/main/java/com/apptolast/familyfilmapp/model/local/User.kt
@@ -7,14 +7,12 @@ import java.util.Locale
 data class User(
     val id: String,
     val email: String,
-    val userName: String,
     val language: String,
     val statusMovies: Map<String, MovieStatus>, // Map with key-value pair: MovieId, Status
 ) {
     constructor() : this(
         id = "",
         email = "",
-        userName = "",
         language = "",
         statusMovies = mapOf(),
     )
@@ -23,7 +21,6 @@ data class User(
 fun FirebaseUser.toDomainUserModel(): User = User(
     id = this.uid,
     email = this.email ?: "email not found",
-    userName = this.displayName ?: "display name not found",
     language = Locale.getDefault().toLanguageTag(),
     statusMovies = mapOf(),
 )

--- a/app/src/main/java/com/apptolast/familyfilmapp/model/room/UserTable.kt
+++ b/app/src/main/java/com/apptolast/familyfilmapp/model/room/UserTable.kt
@@ -28,7 +28,6 @@ data class UserTable(
 fun UserTable.toUser() = User(
     id = userId,
     email = email,
-    userName = "",
     language = language,
     statusMovies = statusMovies,
 )

--- a/app/src/main/java/com/apptolast/familyfilmapp/model/room/UserTable.kt
+++ b/app/src/main/java/com/apptolast/familyfilmapp/model/room/UserTable.kt
@@ -26,7 +26,7 @@ data class UserTable(
 }
 
 fun UserTable.toUser() = User(
-    uid = userId,
+    id = userId,
     email = email,
     userName = "",
     language = language,
@@ -34,7 +34,7 @@ fun UserTable.toUser() = User(
 )
 
 fun User.toUserTable() = UserTable(
-    userId = uid,
+    userId = id,
     email = email,
     language = language,
     statusMovies = statusMovies,

--- a/app/src/main/java/com/apptolast/familyfilmapp/repositories/datasources/FirebaseDatabaseDatasource.kt
+++ b/app/src/main/java/com/apptolast/familyfilmapp/repositories/datasources/FirebaseDatabaseDatasource.kt
@@ -74,7 +74,7 @@ class FirebaseDatabaseDatasourceImpl @Inject constructor(
 
     override fun createUser(user: User, success: (Void?) -> Unit, failure: (Exception) -> Unit) {
         usersCollection
-            .document(user.uid)
+            .document(user.id)
             .set(user)
             .addOnSuccessListener(success)
             .addOnFailureListener(failure)
@@ -161,7 +161,7 @@ class FirebaseDatabaseDatasourceImpl @Inject constructor(
         )
 
         usersCollection
-            .document(user.uid)
+            .document(user.id)
             .update(updates)
             .addOnSuccessListener(success)
             .addOnFailureListener {
@@ -170,7 +170,7 @@ class FirebaseDatabaseDatasourceImpl @Inject constructor(
     }
 
     override fun deleteUser(user: User, success: () -> Unit, failure: (Exception) -> Unit) {
-        usersCollection.document(user.uid)
+        usersCollection.document(user.id)
             .delete()
             .addOnSuccessListener {
                 Timber.d("User deleted from Firestore: ${user.email}")
@@ -248,9 +248,9 @@ class FirebaseDatabaseDatasourceImpl @Inject constructor(
         val uuid = UUID.randomUUID().toString()
         val group = Group().copy(
             id = uuid,
-            ownerId = user.uid,
+            ownerId = user.id,
             name = groupName,
-            users = listOf(user.uid), // Store user IDs, not the entire User object
+            users = listOf(user.id), // Store user IDs, not the entire User object
             lastUpdated = Calendar.getInstance().time, // Set the initial lastUpdated timestamp
         )
 
@@ -317,8 +317,8 @@ class FirebaseDatabaseDatasourceImpl @Inject constructor(
 
                 val updatedUsers = group.users.toMutableList()
                 // If the email is not found in the group's user list, add it
-                if (user.uid !in updatedUsers) {
-                    updatedUsers.add(user.uid)
+                if (user.id !in updatedUsers) {
+                    updatedUsers.add(user.id)
 
                     val updatedGroup = group.copy(
                         users = updatedUsers,
@@ -341,7 +341,7 @@ class FirebaseDatabaseDatasourceImpl @Inject constructor(
 
     override fun deleteMember(group: Group, user: User, success: () -> Unit, failure: (Exception) -> Unit) {
         val updatedUsers = group.users.toMutableList().apply {
-            remove(user.uid)
+            remove(user.id)
         }
 
         val updatedGroup = group.copy(

--- a/app/src/main/java/com/apptolast/familyfilmapp/ui/screens/groups/GroupsScreen.kt
+++ b/app/src/main/java/com/apptolast/familyfilmapp/ui/screens/groups/GroupsScreen.kt
@@ -432,7 +432,7 @@ private fun GroupContentPreview() {
                 Group().copy(name = "name 3"),
             ),
             groupUsers = listOf(
-                User().copy(uid = "1", email = "a@a.com"),
+                User().copy(id = "1", email = "a@a.com"),
             ),
             moviesToWatch = listOf(
                 Movie().copy(id = 1, title = "Title 1", overview = "Description 1"),

--- a/app/src/main/java/com/apptolast/familyfilmapp/ui/screens/groups/components/GroupCard.kt
+++ b/app/src/main/java/com/apptolast/familyfilmapp/ui/screens/groups/components/GroupCard.kt
@@ -77,10 +77,10 @@ fun GroupCard(
                     style = MaterialTheme.typography.titleLarge,
                     modifier = Modifier
                         .weight(1f) // Assign weight to text
-                        .padding(top = if (group.ownerId == userOwner.uid) 0.dp else 10.dp),
+                        .padding(top = if (group.ownerId == userOwner.id) 0.dp else 10.dp),
                 )
 
-                if (group.ownerId == userOwner.uid) {
+                if (group.ownerId == userOwner.id) {
                     IconButton(onClick = onChangeGroupName) {
                         Icon(
                             imageVector = Icons.Filled.ModeEditOutline,
@@ -98,7 +98,7 @@ fun GroupCard(
                 horizontalArrangement = Arrangement.SpaceAround,
                 verticalAlignment = Alignment.CenterVertically,
             ) {
-                if (group.ownerId.equals(userOwner.uid)) {
+                if (group.ownerId.equals(userOwner.id)) {
                     OutlinedButton(onClick = onAddMember) {
                         Icon(imageVector = Icons.Filled.Add, contentDescription = "Add")
                         Text(text = stringResource(id = R.string.groups_text_add_member))
@@ -119,7 +119,7 @@ fun GroupCard(
                         confirmValueChange = {
                             when (it) {
                                 SwipeToDismissBoxValue.EndToStart -> {
-                                    if (group.ownerId != user.uid) {
+                                    if (group.ownerId != user.id) {
                                         onDeleteUser(user)
                                         true
                                     } else {
@@ -135,7 +135,7 @@ fun GroupCard(
 
                     SwipeToDismissBox(
                         state = swipeState,
-                        enableDismissFromEndToStart = userOwner.uid == group.ownerId,
+                        enableDismissFromEndToStart = userOwner.id == group.ownerId,
                         enableDismissFromStartToEnd = false,
                         backgroundContent = {
 //                            Box(
@@ -203,7 +203,7 @@ fun GroupCard(
 private fun GroupCardOwnerPreview() {
     FamilyFilmAppTheme {
         GroupCard(
-            userOwner = User().copy(uid = "1"),
+            userOwner = User().copy(id = "1"),
             group = Group().copy(
                 id = "1",
                 ownerId = "1",
@@ -215,9 +215,9 @@ private fun GroupCardOwnerPreview() {
                 ),
             ),
             groupUsers = listOf(
-                User().copy(uid = "1", email = "a@a.com"),
-                User().copy(uid = "2", email = "b@b.com"),
-                User().copy(uid = "3", email = "c@c.com"),
+                User().copy(id = "1", email = "a@a.com"),
+                User().copy(id = "2", email = "b@b.com"),
+                User().copy(id = "3", email = "c@c.com"),
             ),
         )
     }
@@ -228,7 +228,7 @@ private fun GroupCardOwnerPreview() {
 private fun GroupCardNotOwnerPreview() {
     FamilyFilmAppTheme {
         GroupCard(
-            userOwner = User().copy(uid = "2"),
+            userOwner = User().copy(id = "2"),
             group = Group().copy(
                 id = "1",
                 ownerId = "2",
@@ -240,9 +240,9 @@ private fun GroupCardNotOwnerPreview() {
                 ),
             ),
             groupUsers = listOf(
-                User().copy(uid = "1", email = "a@a.com"),
-                User().copy(uid = "2", email = "b@b.com"),
-                User().copy(uid = "3", email = "c@c.com"),
+                User().copy(id = "1", email = "a@a.com"),
+                User().copy(id = "2", email = "b@b.com"),
+                User().copy(id = "3", email = "c@c.com"),
             ),
         )
     }

--- a/app/src/main/java/com/apptolast/familyfilmapp/ui/sharedViewmodel/AuthViewModel.kt
+++ b/app/src/main/java/com/apptolast/familyfilmapp/ui/sharedViewmodel/AuthViewModel.kt
@@ -276,7 +276,7 @@ class AuthViewModel @Inject constructor(
         val currentUser = (authState.value as? AuthState.Authenticated)?.user
         if (currentUser != null) {
             // Get user data from repository
-            repository.getUserById(currentUser.uid).take(1).collectLatest { user ->
+            repository.getUserById(currentUser.id).take(1).collectLatest { user ->
                 // Delete from Firestore
                 repository.deleteUser(
                     user = user,
@@ -334,7 +334,7 @@ class AuthViewModel @Inject constructor(
     fun createNewUser(user: User) {
         repository.createUser(
             User().copy(
-                uid = user.uid,
+                id = user.id,
                 email = user.email,
                 language = Locale.getDefault().toLanguageTag(),
             ),

--- a/distribution/whatsnew/whatsnew-en-GB
+++ b/distribution/whatsnew/whatsnew-en-GB
@@ -1,1 +1,1 @@
-Enable minify and R8 and fix login issue
+Fix uid that are causing problems adding members

--- a/distribution/whatsnew/whatsnew-es-ES
+++ b/distribution/whatsnew/whatsnew-es-ES
@@ -1,1 +1,1 @@
-Habilitar minify y fallo del login corregido
+Arreglar uid que se están generando errores al agregar miembros


### PR DESCRIPTION
- Replaced usages of `uid` with `id` across the codebase in `User` models and related operations.
- Updated Firebase and Room database interactions to use `id` for user identification.
- Corrected `ownerId` in the `GroupCard` to use user's `id`.
- Updated the Spanish and English changelogs to reflect the fix of problems adding members.
- Update `versionCode` and `versionName` to 16 and 0.3.14.